### PR TITLE
throw exception when key is not found

### DIFF
--- a/src/JsonEncryptor.Application/Features/Encryptors/JsonEncryption.cs
+++ b/src/JsonEncryptor.Application/Features/Encryptors/JsonEncryption.cs
@@ -45,7 +45,7 @@ public class JsonEncryption : IJsonEncryption
 
             if (value is null)
             {
-                continue;
+                throw new KeyNotFoundException($"'{key}' was not found. Please ensure that the key is entered correctly. Use '.' to go one level deeper. For arrays, ensure that index is given.");
             }
 
             var encryptedValue = _aesEncryptionService.Encrypt(value, aesKey, aesKeySize, iv);

--- a/tests/JsonEncryptor.Application.Tests.Unit/Features/Encryptors/JsonEncryptionTests.cs
+++ b/tests/JsonEncryptor.Application.Tests.Unit/Features/Encryptors/JsonEncryptionTests.cs
@@ -106,6 +106,27 @@ public class JsonEncryptionTests
     }
 
     [Fact]
+    public void Encrypt_ShouldThrowException_WhenKeyNotFound()
+    {
+        // Arrange
+        string json = "{\"name\":\"John Doe\"}";
+        List<string> keysToEncrypt = new List<string> { "missingKey" };
+        string aesKey = "myAesKey";
+        int aesKeySize = 256;
+        string iv = "myInitializationVector";
+
+        var jsonService = Substitute.For<IJsonService>();
+        jsonService.GetValueFromKey<string>(json, "missingKey").Returns((string?)null);
+        var jsonEncryptor = new JsonEncryption(jsonService, _aesEncryptionService);
+
+        // Act
+        Action act = () => jsonEncryptor.Encrypt(json, keysToEncrypt, aesKey, aesKeySize, iv);
+
+        // Assert
+        act.Should().Throw<KeyNotFoundException>();
+    }
+
+    [Fact]
     public void Decrypt_ShouldReturnDecryptedJson_WhenInputIsValid()
     {
         // Arrange


### PR DESCRIPTION
The application should tell the user when the key provided by them is not found. This will inform them to double check their syntax so that they know it is not due to a bug.